### PR TITLE
chore: fix same name in workspaces

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "kreate",
+  "name": "kreate-frontend",
   "displayName": "Kreate",
   "description": "Provide templates and documentation to create Kubernetes resources",
   "version": "0.1.0",


### PR DESCRIPTION
https://github.com/podman-desktop/extension-kreate/actions/runs/13837919575/job/38717607649

```
[0] Exit prior to config file resolving
[0] cause
[0] must not have multiple workspaces with the same name
[0] package 'kreate' has conflicts in the following paths:
[0]     /home/runner/work/extension-kreate/extension-kreate/packages/backend
[0]     /home/runner/work/extension-kreate/extension-kreate/packages/frontend

```