### PR TITLE
chore: remove unnecessary override

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
   },
   "pnpm": {
     "overrides": {
-      "cssstyle>@asamuzakjp/css-color": "^2.8.3-b.2",
       "@babel/runtime": "^7.26.10"
     },
     "ignoredBuiltDependencies": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,6 @@ settings:
 overrides:
   string-width: ^4.2.0
   wrap-ansi: ^7.0.0
-  cssstyle>@asamuzakjp/css-color: ^2.8.3-b.2
   '@babel/runtime': ^7.26.10
 
 importers:


### PR DESCRIPTION
Removing this override, as it seems outdated, and I suspect it makes the updates of `svlete` by dependabot fail