### PR TITLE
feat: create namespace

### DIFF
--- a/packages/backend/src/api-impl.spec.ts
+++ b/packages/backend/src/api-impl.spec.ts
@@ -48,7 +48,7 @@ describe('', () => {
 
   test('getCommands without parent', async () => {
     const commands = await api.getCommands();
-    expect(commands).toEqual(['configmap', 'deployment', 'ingress', 'pod', 'secret', 'service']);
+    expect(commands).toEqual(['configmap', 'deployment', 'ingress', 'namespace', 'pod', 'secret', 'service']);
   });
 
   test('getCommands with parent', async () => {

--- a/packages/backend/src/assets/commands.json
+++ b/packages/backend/src/assets/commands.json
@@ -149,6 +149,25 @@
       ]
     },
     {
+      "name": "namespace",
+      "args": [
+        {
+          "name": "name",
+          "label": "Name",
+          "description": "Name of the namespace to create",
+          "required": true
+        }
+      ],
+      "cli": [
+        "kubectl",
+        "create",
+        "namespace",
+        "--dry-run=client",
+        "-o",
+        "yaml"
+      ]
+    },
+    {
       "name": "pod",
       "args": [
         {


### PR DESCRIPTION
Helpful when working with https://github.com/podman-desktop/extension-kubernetes-dashboard which supports listing (and soon deleting) namespaces