### PR TITLE
fix: resolve CVE-2026-32141 in flatted

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,8 @@
       "concurrently>lodash": "^4.17.23",
       "minimatch>brace-expansion": "^2.0.2",
       "minimatch@^3.0.0": "^3.1.4",
-      "minimatch@~9.0.0": "^9.0.7"
+      "minimatch@~9.0.0": "^9.0.7",
+      "flatted": ">=3.4.0"
     },
     "ignoredBuiltDependencies": [
       "@tailwindcss/oxide",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,7 @@ overrides:
   minimatch>brace-expansion: ^2.0.2
   minimatch@^3.0.0: ^3.1.4
   minimatch@~9.0.0: ^9.0.7
+  flatted: '>=3.4.0'
 
 importers:
 
@@ -2005,8 +2006,8 @@ packages:
     resolution: {integrity: sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==}
     engines: {node: ^10.12.0 || >=12.0.0}
 
-  flatted@3.3.3:
-    resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
+  flatted@3.4.2:
+    resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
@@ -5211,11 +5212,11 @@ snapshots:
 
   flat-cache@3.2.0:
     dependencies:
-      flatted: 3.3.3
+      flatted: 3.4.2
       keyv: 4.5.4
       rimraf: 3.0.2
 
-  flatted@3.3.3: {}
+  flatted@3.4.2: {}
 
   for-each@0.3.5:
     dependencies:


### PR DESCRIPTION
### What does this PR do?

Fix high severity vulnerability CVE-2026-32141 in `flatted`.

**Advisory**: flatted vulnerable to unbounded recursion DoS in parse() revive phase
**Vulnerable versions**: <3.4.0
**Patched versions**: >=3.4.0
**Advisory URL**: https://github.com/advisories/GHSA-25h7-pfq9-p65f

### Screenshot / video of UI

N/A - dependency update only.

### What issues does this PR fix or reference?

Fixes CVE-2026-32141: _flatted vulnerable to unbounded recursion DoS in parse() revive phase_

### How to test this PR?

Run `pnpm audit` and verify CVE-2026-32141 is no longer reported