### PR TITLE
fix: resolve CVE-2026-4800 in lodash

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "overrides": {
       "minimatch>@isaacs/brace-expansion": "^5.0.1",
       "test-exclude>glob": "^10.5.0",
-      "concurrently>lodash": "^4.17.23",
+      "concurrently>lodash": ">=4.18.0",
       "minimatch>brace-expansion": "^2.0.2",
       "minimatch@^3.0.0": "^3.1.4",
       "minimatch@~9.0.0": "^9.0.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ overrides:
   wrap-ansi: ^7.0.0
   minimatch>@isaacs/brace-expansion: ^5.0.1
   test-exclude>glob: ^10.5.0
-  concurrently>lodash: ^4.17.23
+  concurrently>lodash: '>=4.18.0'
   minimatch>brace-expansion: ^2.0.2
   minimatch@^3.0.0: ^3.1.4
   minimatch@~9.0.0: ^9.0.7
@@ -2462,8 +2462,8 @@ packages:
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
-  lodash@4.17.23:
-    resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
+  lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
   lru-cache@11.3.5:
     resolution: {integrity: sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==}
@@ -4655,7 +4655,7 @@ snapshots:
   concurrently@9.2.0:
     dependencies:
       chalk: 4.1.2
-      lodash: 4.17.23
+      lodash: 4.18.1
       rxjs: 7.8.2
       shell-quote: 1.8.3
       supports-color: 8.1.1
@@ -5654,7 +5654,7 @@ snapshots:
 
   lodash.merge@4.6.2: {}
 
-  lodash@4.17.23: {}
+  lodash@4.18.1: {}
 
   lru-cache@11.3.5: {}
 


### PR DESCRIPTION
### What does this PR do?

Fix high severity vulnerability CVE-2026-4800 in `lodash`.

**Advisory**: lodash vulnerable to Code Injection via `_.template` imports key names
**Vulnerable versions**: >=4.0.0 <=4.17.23
**Patched versions**: >=4.18.0
**Advisory URL**: https://github.com/advisories/GHSA-r5fr-rjxr-66jc

### Screenshot / video of UI

N/A - dependency update only.

### What issues does this PR fix or reference?

Fixes CVE-2026-4800: _lodash vulnerable to Code Injection via `_.template` imports key names_

### How to test this PR?

Run `pnpm audit` and verify CVE-2026-4800 is no longer reported