### PR TITLE
fix: resolve CVE-2025-69873 in ajv

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,8 @@
       "minimatch@^3.0.0": "^3.1.4",
       "minimatch@~9.0.0": "^9.0.7",
       "flatted": ">=3.4.0",
-      "picomatch@>=4.0.0": ">=4.0.4"
+      "picomatch@>=4.0.0": ">=4.0.4",
+      "ajv@<6.14.0": "^6.14.0"
     },
     "ignoredBuiltDependencies": [
       "@tailwindcss/oxide",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,7 @@ overrides:
   minimatch@~9.0.0: ^9.0.7
   flatted: '>=3.4.0'
   picomatch@>=4.0.0: '>=4.0.4'
+  ajv@<6.14.0: ^6.14.0
 
 importers:
 
@@ -1435,8 +1436,8 @@ packages:
       ajv:
         optional: true
 
-  ajv@6.12.6:
-    resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
+  ajv@6.15.0:
+    resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
 
   ajv@8.20.0:
     resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
@@ -3577,7 +3578,7 @@ snapshots:
 
   '@eslint/eslintrc@2.1.4':
     dependencies:
-      ajv: 6.12.6
+      ajv: 6.15.0
       debug: 4.4.1
       espree: 9.6.1
       globals: 13.24.0
@@ -4449,7 +4450,7 @@ snapshots:
     optionalDependencies:
       ajv: 8.20.0
 
-  ajv@6.12.6:
+  ajv@6.15.0:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-json-stable-stringify: 2.1.0
@@ -5095,7 +5096,7 @@ snapshots:
       '@humanwhocodes/module-importer': 1.0.1
       '@nodelib/fs.walk': 1.2.8
       '@ungap/structured-clone': 1.3.0
-      ajv: 6.12.6
+      ajv: 6.15.0
       chalk: 4.1.2
       cross-spawn: 7.0.6
       debug: 4.4.1


### PR DESCRIPTION
### What does this PR do?

Fix moderate severity vulnerability CVE-2025-69873 in `ajv`.

**Advisory**: ajv has ReDoS when using `$data` option
**Vulnerable versions**: <6.14.0
**Patched versions**: >=6.14.0
**Advisory URL**: https://github.com/advisories/GHSA-2g4f-4pwh-qvx6

### Screenshot / video of UI

N/A - dependency update only.

### What issues does this PR fix or reference?

Fixes CVE-2025-69873: _ajv has ReDoS when using `$data` option_

### How to test this PR?

Run `pnpm audit` and verify CVE-2025-69873 is no longer reported