### PR TITLE
chore: add repository/homepage fields to extension package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,8 @@
   "name": "kreate-monorepo",
   "displayName": "Kreate",
   "description": "Provide templates and documentation to create Kubernetes resources",
+  "repository": "https://github.com/podman-desktop/extension-kreate",
+  "homepage": "https://github.com/podman-desktop/extension-kreate#readme",
   "version": "0.4.0-next",
   "icon": "icon.png",
   "publisher": "podman-desktop",


### PR DESCRIPTION
## Summary
- add missing `homepage` field in extension `package.json`
- ensure both `repository` and `homepage` point to the canonical GitHub repo URL
- closes #751

## Test plan
- [x] verify `package.json` contains both `repository` and `homepage`
- [x] run `git diff main...HEAD` and confirm only metadata change is included

Made with [Cursor](https://cursor.com)