### PR TITLE
fix: prevent Vite 8 from bundling node-fetch's browser shim

### DIFF
--- a/packages/backend/vite.config.js
+++ b/packages/backend/vite.config.js
@@ -35,6 +35,7 @@ const config = {
       '/@gen/': join(PACKAGE_ROOT, 'src-generated') + '/',
       '/@shared/': join(PACKAGE_ROOT, '../shared') + '/',
     },
+    mainFields: ['module', 'jsnext:main', 'jsnext'],
   },
   build: {
     sourcemap: 'inline',


### PR DESCRIPTION
Vite 8 (with Rolldown) defaults resolve.mainFields to ["browser", "module", ...], which causes it to pick node-fetch's browser.js shim instead of the real implementation. That shim delegates to globalThis.fetch (Node.js native fetch / undici), which silently ignores the `agent` option used by @kubernetes/client-node's applyToFetchOptions to carry the cluster CA certificate. As a result, TLS verification against the Kubernetes API server fails with UNABLE_TO_VERIFY_LEAF_SIGNATURE.

Setting mainFields to the standard server-side list (excluding "browser") makes Vite resolve node-fetch's real ESM build, which honours the `agent` option and applies the CA cert correctly.

Fixes #833 