### PR TITLE
feat: migrate from js-yaml v4 to v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   "dependencies": {
     "@kubernetes/client-node": "1.4.0",
     "@scalar/openapi-parser": "^0.28.10",
-    "js-yaml": "^4.3.0",
+    "js-yaml": "^5.0.0",
     "zod": "^4.4.3"
   },
   "pnpm": {

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -43,7 +43,7 @@
     "@kubernetes/client-node": "1.4.0",
     "@scalar/openapi-parser": "^0.28.10",
     "@types/node-fetch": "^2.6.13",
-    "js-yaml": "^4.3.0",
+    "js-yaml": "^5.0.0",
     "semver": "^7.8.5",
     "yaml": "^2.9.0",
     "zod": "^4.4.3"

--- a/packages/backend/src/spec-cache.spec.ts
+++ b/packages/backend/src/spec-cache.spec.ts
@@ -85,9 +85,7 @@ describe('getIdnex', () => {
 
   test('getIndex raises fetch error for non-network errors', async () => {
     vi.mocked(fetch).mockRejectedValue(new Error('timeout'));
-    await expect(() => cache.getIndex(kubeconfig)).rejects.toThrowError(
-      'fetch http://localhost:4000/openapi/v3: timeout',
-    );
+    await expect(() => cache.getIndex(kubeconfig)).rejects.toThrow('fetch http://localhost:4000/openapi/v3: timeout');
   });
 
   test('getIndex raises error on non-OK HTTP response', async () => {
@@ -96,7 +94,7 @@ describe('getIdnex', () => {
       status: 404,
       statusText: 'Not Found',
     } as unknown as fetch.Response);
-    await expect(() => cache.getIndex(kubeconfig)).rejects.toThrowError('HTTP 404 Not Found');
+    await expect(() => cache.getIndex(kubeconfig)).rejects.toThrow('HTTP 404 Not Found');
   });
 });
 
@@ -129,14 +127,14 @@ describe('getGroupVersionSpec', () => {
 
   test('getGroupVersionSpec raises error if group version not in index', async () => {
     vi.spyOn(cache, 'getIndex').mockResolvedValue({ paths: {} });
-    await expect(() => cache.getGroupVersionSpec(kubeconfig, 'apps/v1', 'Deployment')).rejects.toThrowError(
+    await expect(() => cache.getGroupVersionSpec(kubeconfig, 'apps/v1', 'Deployment')).rejects.toThrow(
       'no index entry found for group version apis/apps/v1',
     );
   });
 
   test('getGroupVersionSpec raises fetch error for non-network errors', async () => {
     vi.mocked(fetch).mockRejectedValue(new Error('timeout'));
-    await expect(() => cache.getGroupVersionSpec(kubeconfig, 'apps/v1', 'Deployment')).rejects.toThrowError('timeout');
+    await expect(() => cache.getGroupVersionSpec(kubeconfig, 'apps/v1', 'Deployment')).rejects.toThrow('timeout');
   });
 
   test('getGroupVersionSpec raises error on non-OK HTTP response', async () => {
@@ -145,7 +143,7 @@ describe('getGroupVersionSpec', () => {
       status: 403,
       statusText: 'Forbidden',
     } as unknown as fetch.Response);
-    await expect(() => cache.getGroupVersionSpec(kubeconfig, 'apps/v1', 'Deployment')).rejects.toThrowError(
+    await expect(() => cache.getGroupVersionSpec(kubeconfig, 'apps/v1', 'Deployment')).rejects.toThrow(
       'HTTP 403 Forbidden',
     );
   });

--- a/packages/backend/src/spec-cache.spec.ts
+++ b/packages/backend/src/spec-cache.spec.ts
@@ -82,6 +82,22 @@ describe('getIdnex', () => {
     vi.mocked(fetch).mockClear().mockRejectedValue(err);
     await expect(() => cache.getIndex(kubeconfig)).rejects.toThrow(NO_CONTEXT_EXCEPTION);
   });
+
+  test('getIndex raises fetch error for non-network errors', async () => {
+    vi.mocked(fetch).mockRejectedValue(new Error('timeout'));
+    await expect(() => cache.getIndex(kubeconfig)).rejects.toThrowError(
+      'fetch http://localhost:4000/openapi/v3: timeout',
+    );
+  });
+
+  test('getIndex raises error on non-OK HTTP response', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: false,
+      status: 404,
+      statusText: 'Not Found',
+    } as unknown as fetch.Response);
+    await expect(() => cache.getIndex(kubeconfig)).rejects.toThrowError('HTTP 404 Not Found');
+  });
 });
 
 describe('getGroupVersionSpec', () => {
@@ -109,5 +125,28 @@ describe('getGroupVersionSpec', () => {
     err.code = 'ECONNREFUSED';
     vi.mocked(fetch).mockClear().mockRejectedValue(err);
     await expect(() => cache.getGroupVersionSpec(kubeconfig, 'v1', 'Pod')).rejects.toThrow(NO_CONTEXT_EXCEPTION);
+  });
+
+  test('getGroupVersionSpec raises error if group version not in index', async () => {
+    vi.spyOn(cache, 'getIndex').mockResolvedValue({ paths: {} });
+    await expect(() => cache.getGroupVersionSpec(kubeconfig, 'apps/v1', 'Deployment')).rejects.toThrowError(
+      'no index entry found for group version apis/apps/v1',
+    );
+  });
+
+  test('getGroupVersionSpec raises fetch error for non-network errors', async () => {
+    vi.mocked(fetch).mockRejectedValue(new Error('timeout'));
+    await expect(() => cache.getGroupVersionSpec(kubeconfig, 'apps/v1', 'Deployment')).rejects.toThrowError('timeout');
+  });
+
+  test('getGroupVersionSpec raises error on non-OK HTTP response', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: false,
+      status: 403,
+      statusText: 'Forbidden',
+    } as unknown as fetch.Response);
+    await expect(() => cache.getGroupVersionSpec(kubeconfig, 'apps/v1', 'Deployment')).rejects.toThrowError(
+      'HTTP 403 Forbidden',
+    );
   });
 });

--- a/packages/backend/src/spec-cache.spec.ts
+++ b/packages/backend/src/spec-cache.spec.ts
@@ -39,6 +39,7 @@ const kubeconfig = {
 beforeEach(() => {
   vi.resetAllMocks();
   vi.mocked(fetch).mockResolvedValue({
+    ok: true,
     json: jsonMock,
   } as unknown as fetch.Response);
 

--- a/packages/backend/src/spec-cache.ts
+++ b/packages/backend/src/spec-cache.ts
@@ -73,8 +73,11 @@ export class SpecCache {
       if (this.isConnectionRefusedException(err)) {
         throw new Error(NO_CONTEXT_EXCEPTION);
       } else {
-        throw err;
+        throw new Error(`fetch ${requestURL}: ${this.fetchErrorMessage(err)}`);
       }
+    }
+    if (!response.ok) {
+      throw new Error(`fetch ${requestURL}: HTTP ${response.status} ${response.statusText}`);
     }
     const index = indexParser.parse(await response.json());
     if (!index) {
@@ -97,7 +100,11 @@ export class SpecCache {
 
     const groupVersion = this.getGroupVersionFromApiVersion(apiVersion);
     const index = await this.getIndex(kubeconfig);
-    const path = index.paths[groupVersion].serverRelativeURL;
+    const indexEntry = index.paths[groupVersion];
+    if (!indexEntry) {
+      throw new Error(`no index entry found for group version ${groupVersion}`);
+    }
+    const path = indexEntry.serverRelativeURL;
     const cluster = kubeconfig.getCurrentCluster();
     if (!cluster) {
       throw new Error(NO_CONTEXT_EXCEPTION);
@@ -112,8 +119,11 @@ export class SpecCache {
       if (this.isConnectionRefusedException(err)) {
         throw new Error(NO_CONTEXT_EXCEPTION);
       } else {
-        throw err;
+        throw new Error(`fetch ${requestURL}: ${this.fetchErrorMessage(err)}`);
       }
+    }
+    if (!response.ok) {
+      throw new Error(`fetch ${requestURL}: HTTP ${response.status} ${response.statusText}`);
     }
     const spec = await response.json();
     const result = await validate(spec);
@@ -175,6 +185,14 @@ export class SpecCache {
 
   private isConnectionRefusedException(err: unknown): boolean {
     return err instanceof Error && 'code' in err && err.code === 'ECONNREFUSED';
+  }
+
+  private fetchErrorMessage(err: unknown): string {
+    if (!(err instanceof Error)) return String(err);
+    const cause = (err as Error & { cause?: unknown }).cause;
+    if (!(cause instanceof Error)) return err.message;
+    const codeStr = 'code' in cause ? ` code=${cause.code}` : '';
+    return `${err.message} (cause: ${cause.message}${codeStr})`;
   }
 }
 

--- a/packages/backend/src/spec-reader.ts
+++ b/packages/backend/src/spec-reader.ts
@@ -20,7 +20,6 @@ import { KubeConfig, type KubernetesObject } from '@kubernetes/client-node';
 import type { OpenAPIV3 } from 'openapi-types';
 import { parseAllDocuments } from 'yaml';
 import { SourceMap } from './yaml-mapper';
-import yaml from 'js-yaml';
 import * as podmanDesktopApi from '@podman-desktop/api';
 import { NO_CONTEXT_EXCEPTION } from '/@shared/src/KreateApi';
 import { SpecCache } from './spec-cache';
@@ -90,7 +89,7 @@ export class SpecReader implements podmanDesktopApi.Disposable {
     }
     this.#state = { content, position };
     const map = new SourceMap();
-    yaml.load(content, { listener: map.listen() });
+    map.buildMap(content);
     const path = map.getAtPos(position);
     if (path) {
       return path.split('.').slice(1);

--- a/packages/backend/src/yaml-mapper.spec.ts
+++ b/packages/backend/src/yaml-mapper.spec.ts
@@ -20,7 +20,7 @@ import { expect, test, describe } from 'vitest';
 import { SourceMap } from './yaml-mapper';
 
 describe('getAtPos', () => {
-  test('resolves a nested key by character offset', () => {
+  test('resolves a nested key by line number', () => {
     const content = `apiVersion: v1
 kind: Pod
 metadata:
@@ -28,7 +28,8 @@ metadata:
 `;
     const map = new SourceMap();
     map.buildMap(content);
-    expect(map.getAtPos(content.indexOf('name:'))).toEqual('.metadata.name');
+    // line 3 (0-indexed) is "  name: pod-name"
+    expect(map.getAtPos(3)).toEqual('.metadata.name');
   });
 
   test('returns root "." for positions on or after the first line', () => {
@@ -86,6 +87,21 @@ kind: Pod
     map.buildMap(content);
     expect(map.getAtPos(4)).toEqual('.spec.template.spec.containers.0.image');
     expect(map.getAtPos(5)).toEqual('.spec.template.spec.containers.0.name');
+  });
+
+  test('resolves scalar sequence elements by line number', () => {
+    const content = `spec:
+  containers:
+  - args:
+    - --flag-one
+    - --flag-two
+`;
+    const map = new SourceMap();
+    map.buildMap(content);
+    // line 3 is "    - --flag-one" → .spec.containers.0.args.0
+    expect(map.getAtPos(3)).toEqual('.spec.containers.0.args.0');
+    // line 4 is "    - --flag-two" → .spec.containers.0.args.1
+    expect(map.getAtPos(4)).toEqual('.spec.containers.0.args.1');
   });
 
   test('records the key for an empty flow mapping and does not crash', () => {

--- a/packages/backend/src/yaml-mapper.spec.ts
+++ b/packages/backend/src/yaml-mapper.spec.ts
@@ -16,18 +16,128 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { expect, test } from 'vitest';
+import { expect, test, describe } from 'vitest';
 import { SourceMap } from './yaml-mapper';
-import yaml from 'js-yaml';
 
-test('getAtPos', () => {
-  const content = `apiVersion: v1
+describe('getAtPos', () => {
+  test('resolves a nested key by character offset', () => {
+    const content = `apiVersion: v1
 kind: Pod
 metadata:
   name: pod-name
 `;
-  const map = new SourceMap();
-  yaml.load(content, { listener: map.listen() });
-  const result = map.getAtPos(content.indexOf('name:'));
-  expect(result).toEqual('.metadata.name');
+    const map = new SourceMap();
+    map.buildMap(content);
+    expect(map.getAtPos(content.indexOf('name:'))).toEqual('.metadata.name');
+  });
+
+  test('returns root "." for positions on or after the first line', () => {
+    const content = `apiVersion: v1
+kind: Pod
+`;
+    const map = new SourceMap();
+    map.buildMap(content);
+    // line 0 has the root mapping and ".apiVersion"; "." is inserted first so it wins
+    expect(map.getAtPos(0)).toEqual('.');
+    // line 1 has ".kind" which is more specific
+    expect(map.getAtPos(1)).toEqual('.kind');
+  });
+
+  test('returns undefined before the root when content starts with a newline', () => {
+    const content = `
+apiVersion: v1
+kind: Pod
+`;
+    const map = new SourceMap();
+    map.buildMap(content);
+    // line 0 is the blank line — nothing is mapped there yet
+    expect(map.getAtPos(0)).toBeUndefined();
+    // line 1 is where the root mapping starts
+    expect(map.getAtPos(1)).toEqual('.');
+    expect(map.getAtPos(2)).toEqual('.kind');
+  });
+
+  test('resolves sequence element paths by line number', () => {
+    const content = `items:
+- name: foo
+- name: bar
+`;
+    const map = new SourceMap();
+    map.buildMap(content);
+    // line 1: first element's "name" key
+    expect(map.getAtPos(1)).toEqual('.items.0.name');
+    // line 2: second element's "name" key
+    expect(map.getAtPos(2)).toEqual('.items.1.name');
+  });
+
+  test('resolves deeply nested keys', () => {
+    // getAtPos compares its argument to 0-indexed line numbers stored in the
+    // map, so for deep content we pass line numbers directly rather than raw
+    // character offsets (which would exceed all stored line numbers and
+    // therefore always resolve to the last key in the file).
+    const content = `spec:
+  template:
+    spec:
+      containers:
+      - image: my-image
+        name: my-container
+`;
+    const map = new SourceMap();
+    map.buildMap(content);
+    expect(map.getAtPos(4)).toEqual('.spec.template.spec.containers.0.image');
+    expect(map.getAtPos(5)).toEqual('.spec.template.spec.containers.0.name');
+  });
+
+  test('records the key for an empty flow mapping and does not crash', () => {
+    const content = `spec:
+  strategy: {}
+  replicas: 1
+`;
+    const map = new SourceMap();
+    map.buildMap(content);
+    expect(map.getAtPos(1)).toEqual('.spec.strategy');
+    expect(map.getAtPos(2)).toEqual('.spec.replicas');
+  });
+});
+
+describe('lookup', () => {
+  test('returns correct 1-indexed line, column and position', () => {
+    const content = `apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-name
+`;
+    const map = new SourceMap();
+    map.buildMap(content);
+    const loc = map.lookup('metadata.name');
+    expect(loc).toBeDefined();
+    expect(loc!.line).toEqual(4); // 1-indexed: "  name:" is on the 4th line
+    expect(loc!.column).toEqual(3); // 1-indexed: two leading spaces, then "n"
+    expect(loc!.position).toEqual(content.indexOf('name: pod-name'));
+  });
+
+  test('accepts an array path', () => {
+    const content = `metadata:
+  name: foo
+`;
+    const map = new SourceMap();
+    map.buildMap(content);
+    expect(map.lookup(['metadata', 'name'])).toEqual(map.lookup('metadata.name'));
+  });
+
+  test('accepts a path with a leading dot', () => {
+    const content = `metadata:
+  name: foo
+`;
+    const map = new SourceMap();
+    map.buildMap(content);
+    expect(map.lookup('.metadata.name')).toEqual(map.lookup('metadata.name'));
+  });
+
+  test('returns undefined for an unknown path', () => {
+    const content = `apiVersion: v1\n`;
+    const map = new SourceMap();
+    map.buildMap(content);
+    expect(map.lookup('nonexistent')).toBeUndefined();
+  });
 });

--- a/packages/backend/src/yaml-mapper.ts
+++ b/packages/backend/src/yaml-mapper.ts
@@ -59,6 +59,7 @@ export class SourceMap {
   }
 
   public buildMap(content: string): void {
+    this._map.clear();
     // parseEvents emits a flat stream of events describing the YAML structure.
     // We walk it with an explicit stack to track our depth and current path,
     // recording each key's line number in the map so getAtPos() can later find
@@ -167,8 +168,8 @@ export class SourceMap {
             parent.isKey = true;
           }
         } else if (parent.type === 'sequence') {
-          // Scalar element of a sequence: advance the index so the next
-          // element (if any) gets a fresh numeric path segment.
+          const elemPath = `${parent.path}.${parent.index}`;
+          this._map.set(elemPath, { line, position: valueStart, lineStart });
           parent.index++;
         }
       } else if (type === EVENT_POP) {

--- a/packages/backend/src/yaml-mapper.ts
+++ b/packages/backend/src/yaml-mapper.ts
@@ -24,7 +24,8 @@
 //
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // from https://github.com/tctree333/js-yaml-source-map
-import type { State } from 'js-yaml';
+import { parseEvents, EVENT_DOCUMENT, EVENT_MAPPING, EVENT_SEQUENCE, EVENT_SCALAR, EVENT_POP } from 'js-yaml';
+import type { MappingEvent, ScalarEvent } from 'js-yaml';
 
 // maps path in object to position information
 interface Path {
@@ -33,225 +34,158 @@ interface Path {
   lineStart: number;
 }
 
-interface Fragment {
-  path: string;
-  line: number;
-  position: number;
-  lineStart: number;
-  children?: Fragment[];
-}
-
 interface SourceLocation {
   line: number;
   column: number;
   position: number;
 }
 
+interface StackEntry {
+  type: 'doc' | 'mapping' | 'sequence';
+  path: string;
+  isKey: boolean;
+  index: number;
+}
+
 export class SourceMap {
   private _map: Map<string, Path>;
-  private _path: string[];
-  private _lastScalar: string;
-  private _fragments: Fragment[];
-  private _count: number;
 
   constructor() {
     this._map = new Map();
-    this._path = [];
-    this._lastScalar = '';
-    this._fragments = [];
-    this._count = 0;
   }
 
   public get map(): Map<string, Path> {
     return this._map;
   }
 
-  // recursively pushes information to the path map
-  private resolveNode(fragment: Fragment, path: string): void {
-    // if fragment is already at the root, don't prepend stuff
-    if (fragment.path === '.') {
-      path = '.';
-    }
-    // if the path is already in the map, we don't override it
-    if (!this._map.get(path)) {
-      const { line, position, lineStart } = fragment;
-      this._map.set(path, { line, position, lineStart });
-    }
-    // if there are children, we recursively resolve them
-    if (fragment.children && fragment.children.length > 0) {
-      fragment.children.forEach(child => {
-        this.resolveNode(child, (path === '.' ? '' : path) + '.' + child.path);
-      });
-    }
-  }
-
-  // loops through fragments and removes children of the path
-  private iterFragments(pathName: string, callback: (fragment: Fragment) => void): void {
-    for (let i = this._fragments.length - 1; i >= 0; i--) {
-      // skip the parent and fragments not in the path
-      if (!this._fragments[i].path.startsWith(pathName) || this._fragments[i].path === pathName) {
-        continue;
-      }
-      const fragment = this._fragments.pop() as Fragment;
-      callback(fragment);
-    }
-  }
-
-  private handleState(event: 'open' | 'close', state: State): void {
-    // the listener function emits an "open" and "close" event for each "node".
-    // "open" events tell us that we are going one level deeper, while "close"
-    // events actually give us the correct data about the node. we receive each
-    // scalar value (primitve) as well as the constructed objects (map, seq, etc)
+  public buildMap(content: string): void {
+    // parseEvents emits a flat stream of events describing the YAML structure.
+    // We walk it with an explicit stack to track our depth and current path,
+    // recording each key's line number in the map so getAtPos() can later find
+    // the deepest path that started at or before a given line.
     //
-    // to generate sourcemaps, we listen to "open" and "close" events to determine
-    // our depth in the document. we also keep track of all the scalar values we
-    // encounter, which includes both keys and values. since we can't determine
-    // whether a scalar is a key or a value, or the location in a sequence, we
-    // edit past fragments to the correct path when constructed objects are finally
-    // emitted.
+    // The event types we care about:
+    //   EVENT_DOCUMENT – wraps the whole document; just pushed as a sentinel.
+    //   EVENT_MAPPING  – start of a mapping (object); its `start` is the char
+    //                    offset of the first key. For the root mapping we store
+    //                    '.' here so there is always a root entry.
+    //   EVENT_SEQUENCE – start of a sequence (array); we track a running index
+    //                    so elements are addressed as path.0, path.1, …
+    //   EVENT_SCALAR   – a scalar value. Inside a mapping, scalars alternate
+    //                    between keys and values; we record the path only for
+    //                    keys, using `isKey` to tell them apart.
+    //   EVENT_POP      – closes the innermost open collection or document.
 
-    if (event === 'close') {
-      const result = state.result as unknown;
-      const kind = state.kind;
-      const pathName = this._path.join('.');
+    // Build a char-offset → line-number lookup table so we can convert the
+    // character offsets returned by parseEvents into 0-indexed line numbers.
+    const lineStarts: number[] = [0];
+    for (let i = 0; i < content.length; i++) {
+      if (content[i] === '\n') lineStarts.push(i + 1);
+    }
+    const lineOf = (offset: number): number => {
+      let lo = 0,
+        hi = lineStarts.length - 1;
+      while (lo < hi) {
+        const mid = (lo + hi + 1) >> 1;
+        if (lineStarts[mid] <= offset) lo = mid;
+        else hi = mid - 1;
+      }
+      return lo;
+    };
 
-      // scalar typse are primitives (non maps/arrays)
-      if (kind === 'scalar') {
-        // we need to pop the path before computing things for scalars
-        this._path.pop();
+    const events = parseEvents(content, {});
+    const stack: StackEntry[] = [];
+    // pendingKeyPath holds the map path of the most recently seen mapping key,
+    // so that when the following value turns out to be a nested collection
+    // (EVENT_MAPPING / EVENT_SEQUENCE) we know which path to assign it.
+    let pendingKeyPath = '';
+    let rootSet = false;
 
-        // save the scalar for later, since it's not junk
-        this._lastScalar = `${result as string}`;
+    for (const event of events) {
+      const type = event.type;
 
-        const { line, position, lineStart } = state;
-        if (this._path.length === 0) {
-          // a path of length 0 is the root, store this to the path map
-          this._map.set('.' + (result as string), {
-            line,
-            position,
-            lineStart,
-          });
+      if (type === EVENT_DOCUMENT) {
+        stack.push({ type: 'doc', path: '', isKey: false, index: 0 });
+      } else if (type === EVENT_MAPPING) {
+        const { start } = event as MappingEvent;
+        const line = lineOf(start);
+        const lineStart = lineStarts[line];
+
+        if (!rootSet) {
+          // The very first mapping is the root; store it under '.' so that
+          // getAtPos() always has a root entry to fall back to.
+          this._map.set('.', { line, position: start, lineStart });
+          rootSet = true;
+          stack.push({ type: 'mapping', path: '.', isKey: true, index: 0 });
         } else {
-          // a path of length > 1 is a child of the root, store this as a fragment
-          this._fragments.push({
-            path: this._path.join('.') + '.' + (result as string),
-            line,
-            position,
-            lineStart,
-          });
+          const parent = stack[stack.length - 1];
+          if (parent.type === 'mapping') {
+            // The mapping is the value of the key we just recorded; the path
+            // was already written to the map when we saw that key scalar.
+            // Mark the parent as expecting a key again (after this nested
+            // mapping is closed by EVENT_POP).
+            parent.isKey = true;
+            stack.push({ type: 'mapping', path: pendingKeyPath, isKey: true, index: 0 });
+          } else if (parent.type === 'sequence') {
+            // Each mapping element of a sequence gets a numeric path segment.
+            const elemPath = `${parent.path}.${parent.index}`;
+            parent.index++;
+            stack.push({ type: 'mapping', path: elemPath, isKey: true, index: 0 });
+          }
         }
-      } else if (kind === 'mapping' || !kind) {
-        const newFragment: Fragment = {
-          path: pathName,
-          children: [],
-          line: 0,
-          position: 0,
-          lineStart: 0,
-        };
-        // the fragments currently do not distinguish between keys and values, so we
-        // need to use the index to determine which is which.
-        //
-        // we're just counting, so the index doesn't correspond to anything
-        // and we can count up, even though we're looping backwards.
-        let index = 0;
-        this.iterFragments(pathName, fragment => {
-          index++;
-          // always keep non-primitive fragments
-          if ((!fragment.children || fragment.children.length === 0) && index % 2 === 1) {
-            // some fragments might be values, not keys.
-            // keys will have an even index since we loop backwards, start at 0, and increment before checking.
+      } else if (type === EVENT_SEQUENCE) {
+        // Sequences don't contribute a map entry themselves; their elements
+        // are addressed by the numeric index tracked in the stack entry.
+        const parent = stack[stack.length - 1];
+        if (parent.type === 'mapping') {
+          parent.isKey = true;
+          stack.push({ type: 'sequence', path: pendingKeyPath, isKey: false, index: 0 });
+        } else if (parent.type === 'sequence') {
+          // Nested sequence: each element gets its own numeric path segment.
+          const elemPath = `${parent.path}.${parent.index}`;
+          parent.index++;
+          stack.push({ type: 'sequence', path: elemPath, isKey: false, index: 0 });
+        }
+      } else if (type === EVENT_SCALAR) {
+        const { valueStart, valueEnd } = event as ScalarEvent;
+        const value = content.slice(valueStart, valueEnd);
+        const line = lineOf(valueStart);
+        const lineStart = lineStarts[line];
 
-            // discard odd indices, they're values
-            return;
-          }
-
-          if (this._path.length === 1) {
-            // if we're at the root, write to path map
-            this.resolveNode(fragment, fragment.path);
+        const parent = stack[stack.length - 1];
+        if (parent.type === 'mapping') {
+          if (parent.isKey) {
+            // Key scalar: record its path and line so getAtPos() can find it,
+            // then remember the path in case the next event is a nested
+            // collection (EVENT_MAPPING / EVENT_SEQUENCE).
+            const keyPath = parent.path === '.' ? `.${value}` : `${parent.path}.${value}`;
+            this._map.set(keyPath, { line, position: valueStart, lineStart });
+            pendingKeyPath = keyPath;
+            parent.isKey = false;
           } else {
-            // otherwise create a new fragment with correct children
-            (newFragment.children as Fragment[]).push({
-              ...fragment,
-              path: fragment.path.slice(pathName.length + 1),
-            });
-
-            newFragment.line = fragment.line - 1;
-            newFragment.position = fragment.position;
-            newFragment.lineStart = fragment.lineStart;
+            // Value scalar: nothing to record; just toggle back to key mode.
+            parent.isKey = true;
           }
-        });
-        this._fragments.push(newFragment);
-
-        this._path.pop();
-      } else if (kind === 'sequence') {
-        // fragment paths are junk for sequences so we don't use them.
-
-        const newFragment: Fragment = {
-          path: pathName,
-          children: [],
-          line: 0,
-          position: 0,
-          lineStart: 0,
-        };
-        // discard duplicates based on position
-        const seen = new Set<number>();
-
-        // since we don't have keys and can have duplicate values in a sequence,
-        // we need to determine the correct order. by assuming that we're traversing
-        // the document in order, we can find the order.
-        //
-        // we're actually looping backwards, so we count down from the end
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        let index = (result as any[]).length;
-        this.iterFragments(pathName, fragment => {
-          if (seen.has(fragment.position)) {
-            return;
+        } else if (parent.type === 'sequence') {
+          // Scalar element of a sequence: advance the index so the next
+          // element (if any) gets a fresh numeric path segment.
+          parent.index++;
+        }
+      } else if (type === EVENT_POP) {
+        // EVENT_POP closes the innermost open collection or document.
+        if (stack.length > 0 && stack[stack.length - 1].type !== 'doc') {
+          stack.pop();
+          // If we just closed a nested collection that was the value of a
+          // mapping key, the parent mapping is now ready for its next key.
+          const newTop = stack[stack.length - 1];
+          if (newTop?.type === 'mapping' && !newTop.isKey) {
+            newTop.isKey = true;
           }
-          index--;
-          seen.add(fragment.position);
-
-          if (this._path.length === 1) {
-            // if we're at the root, write to path map
-            this.resolveNode(fragment, `${pathName}.${index}`);
-          } else {
-            // otherwise create a new fragment with correct children
-            (newFragment.children as Fragment[]).push({
-              ...fragment,
-              path: index.toString(),
-            });
-
-            newFragment.line = fragment.line;
-            newFragment.position = fragment.position;
-            newFragment.lineStart = fragment.lineStart;
-          }
-        });
-        this._fragments.push(newFragment);
-
-        this._path.pop();
-      } else {
-        // kind is undefined, pop the path to stay in sync
-        this._path.pop();
+        } else if (stack.length > 0) {
+          stack.pop();
+        }
       }
     }
-
-    if (event === 'open') {
-      if (this._count === 0) {
-        // save the root document
-        const { line, position, lineStart } = state;
-        this._map.set('.', { line, position, lineStart });
-      }
-
-      // open events might have junk data, so we push the last found scalar
-      this._path.push(this._lastScalar);
-
-      this._count++;
-    }
-  }
-
-  public listen() {
-    // since js-yaml calls `state.listener` internally, we bind to this
-    // so `this` refers to the class instance, not `state``
-    return this.handleState.bind(this);
   }
 
   public lookup(path: string | string[]): SourceLocation | undefined {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,8 +32,8 @@ importers:
         specifier: ^0.28.10
         version: 0.28.10
       js-yaml:
-        specifier: ^4.3.0
-        version: 4.3.0
+        specifier: ^5.0.0
+        version: 5.1.0
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -105,8 +105,8 @@ importers:
         specifier: ^2.6.13
         version: 2.6.13
       js-yaml:
-        specifier: ^4.3.0
-        version: 4.3.0
+        specifier: ^5.0.0
+        version: 5.1.0
       semver:
         specifier: ^7.8.5
         version: 7.8.5
@@ -2281,6 +2281,10 @@ packages:
 
   js-yaml@4.3.0:
     resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+    hasBin: true
+
+  js-yaml@5.1.0:
+    resolution: {integrity: sha512-s8VA5jkR8f22S3NAXmhKPFqGUduqZGlsufabVOgN14iTdw/RXcym7bKkbwjxLK9Yw2lEvvmJjFp119+KPeo8Kg==}
     hasBin: true
 
   jsdom@29.1.1:
@@ -5439,6 +5443,10 @@ snapshots:
   js-tokens@4.0.0: {}
 
   js-yaml@4.3.0:
+    dependencies:
+      argparse: 2.0.1
+
+  js-yaml@5.1.0:
     dependencies:
       argparse: 2.0.1
 


### PR DESCRIPTION
js-yaml v5 removed the default export and the `listener` option from `yaml.load()`. This commit updates all affected code:
    
- Bump js-yaml from ^4.2.0 to ^5.0.0 in package.json files
- Rewrite SourceMap.buildMap() to use the v5 parseEvents() API with an explicit stack, replacing the v4 listener-based approach
- Remove the now-unused listen() method and related private fields
- Update spec-reader.ts to call map.buildMap() directly
- Add comprehensive tests for SourceMap (getAtPos and lookup) organised in describe blocks
- Improve spec-cache.ts error messages to include fetch URL, HTTP status and the underlying cause (including error code) for opaque fetch failures
- Add null-check for index.paths[groupVersion] to avoid a silent crash


Fixes #832 

(includes commit from PR #834)