### PR TITLE
fix: resolve type errors after @scalar/openapi-parser upgrade to 0.28.8

### DIFF
--- a/packages/backend/src/simplified-spec.spec.ts
+++ b/packages/backend/src/simplified-spec.spec.ts
@@ -24,7 +24,7 @@ import type { OpenAPIV3 } from 'openapi-types';
 import { getSimplifiedSpec, getSubspec } from './simplified-spec';
 
 function isOpenAPIV3Document(doc: unknown): doc is OpenAPIV3.Document {
-  return typeof doc === 'object' && doc !== null && 'openapi' in doc;
+  return typeof doc === 'object' && !!doc && 'openapi' in doc;
 }
 
 test('deployment', async () => {

--- a/packages/backend/src/simplified-spec.spec.ts
+++ b/packages/backend/src/simplified-spec.spec.ts
@@ -23,12 +23,16 @@ import { validate } from '@scalar/openapi-parser';
 import type { OpenAPIV3 } from 'openapi-types';
 import { getSimplifiedSpec, getSubspec } from './simplified-spec';
 
+function isOpenAPIV3Document(doc: unknown): doc is OpenAPIV3.Document {
+  return typeof doc === 'object' && doc !== null && 'openapi' in doc;
+}
+
 test('deployment', async () => {
   const result = await validate(appsv1);
-  if (!result.valid) {
+  if (!result.valid || !isOpenAPIV3Document(result.schema)) {
     throw new Error(`invalid spec`);
   }
-  const document: OpenAPIV3.Document = result.schema;
+  const document = result.schema;
   const spec = document.components?.schemas?.['io.k8s.api.apps.v1.Deployment'];
   if (!spec) {
     throw new Error('Deployment spec not found');
@@ -79,10 +83,10 @@ test('deployment', async () => {
 
 test('deployment with pathInSpec kind', async () => {
   const result = await validate(appsv1);
-  if (!result.valid) {
+  if (!result.valid || !isOpenAPIV3Document(result.schema)) {
     throw new Error(`invalid spec`);
   }
-  const document: OpenAPIV3.Document = result.schema;
+  const document = result.schema;
   const spec = document.components?.schemas?.['io.k8s.api.apps.v1.Deployment'];
   if (!spec) {
     throw new Error('Deployment spec not found');
@@ -98,10 +102,10 @@ test('deployment with pathInSpec kind', async () => {
 
 test('deployment with pathInSpec metadata', async () => {
   const result = await validate(appsv1);
-  if (!result.valid) {
+  if (!result.valid || !isOpenAPIV3Document(result.schema)) {
     throw new Error(`invalid spec`);
   }
-  const document: OpenAPIV3.Document = result.schema;
+  const document = result.schema;
   const spec = document.components?.schemas?.['io.k8s.api.apps.v1.Deployment'];
   if (!spec) {
     throw new Error('Deployment spec not found');
@@ -137,10 +141,10 @@ test('deployment with pathInSpec metadata', async () => {
 
 test('deployment with pathInSpec metadata.name', async () => {
   const result = await validate(appsv1);
-  if (!result.valid) {
+  if (!result.valid || !isOpenAPIV3Document(result.schema)) {
     throw new Error(`invalid spec`);
   }
-  const document: OpenAPIV3.Document = result.schema;
+  const document = result.schema;
   const spec = document.components?.schemas?.['io.k8s.api.apps.v1.Deployment'];
   if (!spec) {
     throw new Error('Deployment spec not found');
@@ -156,10 +160,10 @@ test('deployment with pathInSpec metadata.name', async () => {
 
 test('deployment with pathInSpec metadata.ownerReferences', async () => {
   const result = await validate(appsv1);
-  if (!result.valid) {
+  if (!result.valid || !isOpenAPIV3Document(result.schema)) {
     throw new Error(`invalid spec`);
   }
-  const document: OpenAPIV3.Document = result.schema;
+  const document = result.schema;
   const spec = document.components?.schemas?.['io.k8s.api.apps.v1.Deployment'];
   if (!spec) {
     throw new Error('Deployment spec not found');
@@ -186,10 +190,10 @@ test('deployment with pathInSpec metadata.ownerReferences', async () => {
 
 test('deployment with pathInSpec metadata.ownerReferences.apiVersion', async () => {
   const result = await validate(appsv1);
-  if (!result.valid) {
+  if (!result.valid || !isOpenAPIV3Document(result.schema)) {
     throw new Error(`invalid spec`);
   }
-  const document: OpenAPIV3.Document = result.schema;
+  const document = result.schema;
   const spec = document.components?.schemas?.['io.k8s.api.apps.v1.Deployment'];
   if (!spec) {
     throw new Error('Deployment spec not found');

--- a/packages/backend/src/spec-cache.ts
+++ b/packages/backend/src/spec-cache.ts
@@ -117,10 +117,10 @@ export class SpecCache {
     }
     const spec = await response.json();
     const result = await validate(spec);
-    if (!result.valid) {
+    if (!result.valid || !isOpenAPIV3Document(result.schema)) {
       throw new Error(NO_OPENAPI_EXCEPTION);
     }
-    const document: OpenAPIV3.Document = result.schema;
+    const document = result.schema;
     if (!document.components?.schemas) {
       throw new Error(NO_OPENAPI_EXCEPTION);
     }
@@ -176,4 +176,8 @@ export class SpecCache {
   private isConnectionRefusedException(err: unknown): boolean {
     return err instanceof Error && 'code' in err && err.code === 'ECONNREFUSED';
   }
+}
+
+function isOpenAPIV3Document(doc: unknown): doc is OpenAPIV3.Document {
+  return typeof doc === 'object' && doc !== null && 'openapi' in doc;
 }

--- a/packages/backend/src/spec-cache.ts
+++ b/packages/backend/src/spec-cache.ts
@@ -179,5 +179,5 @@ export class SpecCache {
 }
 
 function isOpenAPIV3Document(doc: unknown): doc is OpenAPIV3.Document {
-  return typeof doc === 'object' && doc !== null && 'openapi' in doc;
+  return typeof doc === 'object' && !!doc && 'openapi' in doc;
 }


### PR DESCRIPTION
The new version types validate()'s result.schema as OpenAPI.Document (a union of V2/V3/V3.1/V3.2), which is no longer directly assignable to OpenAPIV3.Document. Replace the type annotation with an isOpenAPIV3Document type predicate that narrows the type via a runtime openapi property check.