### PR TITLE
fix: resolve CVE-2026-13149 in brace-expansion  

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
       "minimatch>@isaacs/brace-expansion": "^5.0.1",
       "test-exclude>glob": "^10.5.0",
       "concurrently>lodash": ">=4.18.0",
-      "minimatch>brace-expansion": "^2.0.2",
+      "minimatch>brace-expansion": "^2.1.2",
       "minimatch@^3.0.0": "^3.1.4",
       "minimatch@~9.0.0": "^9.0.7",
       "flatted": ">=3.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ overrides:
   minimatch>@isaacs/brace-expansion: ^5.0.1
   test-exclude>glob: ^10.5.0
   concurrently>lodash: '>=4.18.0'
-  minimatch>brace-expansion: ^2.0.2
+  minimatch>brace-expansion: ^2.1.2
   minimatch@^3.0.0: ^3.1.4
   minimatch@~9.0.0: ^9.0.7
   flatted: '>=3.4.0'
@@ -1491,9 +1491,6 @@ packages:
 
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
-
-  brace-expansion@2.1.0:
-    resolution: {integrity: sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==}
 
   brace-expansion@2.1.2:
     resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
@@ -4481,10 +4478,6 @@ snapshots:
     dependencies:
       require-from-string: 2.0.2
 
-  brace-expansion@2.1.0:
-    dependencies:
-      balanced-match: 1.0.2
-
   brace-expansion@2.1.2:
     dependencies:
       balanced-match: 1.0.2
@@ -5613,7 +5606,7 @@ snapshots:
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 2.1.0
+      brace-expansion: 2.1.2
 
   minimatch@9.0.9:
     dependencies:


### PR DESCRIPTION
### What does this PR do?

Fix high severity vulnerability CVE-2026-13149 in `brace-expansion`.

**Advisory**: brace-expansion: DoS via exponential-time expansion of consecutive non-expanding {} groups
**Vulnerable versions**: >=2.0.0 <2.1.2
**Patched versions**: >=2.1.2
**Advisory URL**: https://github.com/advisories/GHSA-3jxr-9vmj-r5cp

### Screenshot / video of UI

N/A - dependency update only.

### What issues does this PR fix or reference?

Fixes CVE-2026-13149: _brace-expansion: DoS via exponential-time expansion of consecutive non-expanding {} groups_

### How to test this PR?

Run `pnpm audit` and verify CVE-2026-13149 is no longer reported