### PR TITLE
fix: resolve CVE-2026-16221 in fast-uri

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,8 @@
       "ws@>=8.0.0 <8.21.0": ">=8.21.0",
       "form-data@>=4.0.0 <4.0.6": ">=4.0.6",
       "undici@>=7.23.0 <7.28.0": "^7.28.0",
-      "shell-quote": ">=1.9.0"
+      "shell-quote": ">=1.9.0",
+      "fast-uri@>=3.0.0 <3.1.4": "3.1.4"
     },
     "ignoredBuiltDependencies": [
       "@tailwindcss/oxide",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,7 @@ overrides:
   form-data@>=4.0.0 <4.0.6: '>=4.0.6'
   undici@>=7.23.0 <7.28.0: ^7.28.0
   shell-quote: '>=1.9.0'
+  fast-uri@>=3.0.0 <3.1.4: 3.1.4
 
 importers:
 
@@ -1920,8 +1921,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@3.1.3:
-    resolution: {integrity: sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==}
+  fast-uri@3.1.4:
+    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
 
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
@@ -4340,7 +4341,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.3
+      fast-uri: 3.1.4
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -5082,7 +5083,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@3.1.3: {}
+  fast-uri@3.1.4: {}
 
   fastq@1.19.1:
     dependencies:


### PR DESCRIPTION
### What does this PR do?

Fix high severity vulnerability CVE-2026-16221 in `fast-uri`.

**Advisory**: fast-uri vulnerable to host confusion via literal backslash authority delimiter
**Vulnerable versions**: >=3.0.0 <=3.1.3
**Patched versions**: >=3.1.4
**Advisory URL**: https://github.com/advisories/GHSA-v2hh-gcrm-f6hx

### Screenshot / video of UI

N/A - dependency update only.

### What issues does this PR fix or reference?

Fixes CVE-2026-16221: _fast-uri vulnerable to host confusion via literal backslash authority delimiter_

### How to test this PR?

Run `pnpm audit` and verify CVE-2026-16221 is no longer reported