### PR TITLE
fix: resolve CVE-2026-59868 in js-yaml 

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   "dependencies": {
     "@kubernetes/client-node": "1.4.0",
     "@scalar/openapi-parser": "^0.28.10",
-    "js-yaml": "^5.0.0",
+    "js-yaml": "^5.2.0",
     "zod": "^4.4.3"
   },
   "pnpm": {

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -43,7 +43,7 @@
     "@kubernetes/client-node": "1.4.0",
     "@scalar/openapi-parser": "^0.28.10",
     "@types/node-fetch": "^2.6.13",
-    "js-yaml": "^5.0.0",
+    "js-yaml": "^5.2.0",
     "semver": "^7.8.5",
     "yaml": "^2.9.0",
     "zod": "^4.4.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,8 +34,8 @@ importers:
         specifier: ^0.28.10
         version: 0.28.10
       js-yaml:
-        specifier: ^5.0.0
-        version: 5.1.0
+        specifier: ^5.2.0
+        version: 5.2.1
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -107,8 +107,8 @@ importers:
         specifier: ^2.6.13
         version: 2.6.13
       js-yaml:
-        specifier: ^5.0.0
-        version: 5.1.0
+        specifier: ^5.2.0
+        version: 5.2.1
       semver:
         specifier: ^7.8.5
         version: 7.8.5
@@ -2282,8 +2282,8 @@ packages:
     resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
     hasBin: true
 
-  js-yaml@5.1.0:
-    resolution: {integrity: sha512-s8VA5jkR8f22S3NAXmhKPFqGUduqZGlsufabVOgN14iTdw/RXcym7bKkbwjxLK9Yw2lEvvmJjFp119+KPeo8Kg==}
+  js-yaml@5.2.1:
+    resolution: {integrity: sha512-zfLtNfQqxVqq3uaTqSkh4x4hZw3KHobGUA0fJUj4wawW8bsQLTVqpHdXSIzidh7o+4lEW36tANuAGdaFx6Zgnw==}
     hasBin: true
 
   jsdom@29.1.1:
@@ -5441,7 +5441,7 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
-  js-yaml@5.1.0:
+  js-yaml@5.2.1:
     dependencies:
       argparse: 2.0.1
 


### PR DESCRIPTION
### What does this PR do?

Fix moderate severity vulnerability CVE-2026-59868 in `js-yaml`.

**Advisory**: js-yaml: YAML merge-key chains can force quadratic CPU consumption in js-yaml
**Vulnerable versions**: >=5.0.0 <=5.1.0
**Patched versions**: >=5.2.0
**Advisory URL**: https://github.com/advisories/GHSA-g796-fgmg-93mv

### Screenshot / video of UI

N/A - dependency update only.

### What issues does this PR fix or reference?

Fixes CVE-2026-59868: _js-yaml: YAML merge-key chains can force quadratic CPU consumption in js-yaml_

### How to test this PR?

Run `pnpm audit` and verify CVE-2026-59868 is no longer reported